### PR TITLE
fixed #57 by adding max width and margin to error labels

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -8,8 +8,8 @@ const fetcher = (url) => fetch(url).then((res) => res.json())
 export default function Home() {
     const { data, error } = useSWR('/api/getsettings', fetcher);
 
-    if (error) return <div>Failed to load</div>
-    if (!data) return <div>Loading...</div>
+    if (error) return <div className="max-w-screen-xl max-auto">Failed to load</div>
+    if (!data) return <div className="max-w-screen-xl max-auto">Loading...</div>
 
     const settings = JSON.parse(data).settings
 

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -14,8 +14,8 @@ export default function Settings() {
     const { data, error } = useSWR('/api/getsettings', fetcher);
     const [currentConfig, setCurrentConfig] = useState(null)
 
-    if (error) return <div>Failed to load</div>
-    if (!data) return <div>Loading...</div>
+    if (error) return <div className="max-w-screen-xl max-auto">Failed to load</div>
+    if (!data) return <div className="max-w-screen-xl max-auto">Loading...</div>
 
     const settings = JSON.parse(data).settings
 


### PR DESCRIPTION
Edited index.js and settings.js to add max width to error labels. Prevents overflowing dashboard.